### PR TITLE
Update crane-operator.v1.4.5.clusterserviceversion.yaml

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/crane-operator.v1.4.5.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/crane-operator.v1.4.5.clusterserviceversion.yaml
@@ -841,7 +841,7 @@ spec:
                 - name: VELERO_REPO
                   value: velero
                 - name: VELERO_TAG
-                  value: release-1.4.5
+                  value: release-1.4.4
                 - name: VELERO_PLUGIN_REPO
                   value: openshift-velero-plugin
                 - name: VELERO_PLUGIN_TAG


### PR DESCRIPTION
There is an issue when deploying crane-operator 1.4.5 on Openshift 4.7. 
Creation of MigrationController fails when setting "migration_velero: true" in the yaml, because then it trys to pull velero:1.4.5 from quay. This tag is not existing, ending up in image pull errors. Same for restic. Please fix that issue, thanks very much.

(I made a RedHat support case for this, they could recreate the problem, and asked me to create an issue at this place. It is case 02968625. Sorry, this change suggestion is not a fix, it is just my insufficient try to raise this issue ...)

**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/crane-operator`
* [ ] I updated channels in the `crane-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
